### PR TITLE
removed an empty object created in pipeline in line 44

### DIFF
--- a/FileSystems/Get-MSIinfo.ps1
+++ b/FileSystems/Get-MSIinfo.ps1
@@ -41,11 +41,11 @@ function Get-MSIinfo {
             $MSIDatabase = $WindowsInstaller.GetType().InvokeMember("OpenDatabase","InvokeMethod",$Null,$WindowsInstaller,@($Path.FullName,0))
             $Query = "SELECT Value FROM Property WHERE Property = '$($Property)'"
             $View = $MSIDatabase.GetType().InvokeMember("OpenView","InvokeMethod",$null,$MSIDatabase,($Query))
-            $View.GetType().InvokeMember("Execute", "InvokeMethod", $null, $View, $null)
+            $null = $View.GetType().InvokeMember("Execute", "InvokeMethod", $null, $View, $null)
             $Record = $View.GetType().InvokeMember("Fetch","InvokeMethod",$null,$View,$null)
             $Value = $Record.GetType().InvokeMember("StringData","GetProperty",$null,$Record,1)
             return $Value
-        } 
+        }
         catch {
             Write-Output $_.Exception.Message
         }


### PR DESCRIPTION
An empty object gets created in pipeline when you do $View.GetType().InvokeMember() and then it gets returned from the function which is probably not desired behaviour.  So I added an assignment to $null to prevent the object creation